### PR TITLE
Privet.Api.Capabilities Issue is returning 200 Error Code

### DIFF
--- a/testcert.py
+++ b/testcert.py
@@ -560,7 +560,10 @@ class Privet(LogoCert):
       raise
     else:
       try:
-        self.assertEqual(response['code'], return_code)
+        if Constants.CAPS['LOCAL_PRINT']:
+          self.assertEqual(response['code'], return_code)
+        else:
+          self.assertNotEqual(response['code'], return_code)
       except AssertionError:
         notes = 'Incorrect return code, found %d' % response['code']
         self.LogTest(test_id, test_name, 'Failed', notes)


### PR DESCRIPTION
Some printers are experiencing issues with Privet.Api.Capabilities, it has been known to return the wrong error code--Error Code 200. Since Kyocera device is exposing capabilities for local printing when it is not registered, it is returning 200. We concluded that 200 is the correct code for Kyocera printers, but may be the wrong error code for other printers.