### PR TITLE
Revert "Make the flow to wait for 60 seconds to find class cp-job-name"

### DIFF
--- a/_chromedriver.py
+++ b/_chromedriver.py
@@ -154,9 +154,6 @@ class ChromeDriver(object):
     try:
       self.GetWait().until(EC.presence_of_all_elements_located((By.CLASS_NAME,
                                                            classname)))
-      if classname == 'cp-job-name':
-        print 'waiting 60 seconds to find class cp-job-name'
-        time.sleep(60)
     except TimeoutException:
       self.logger.error('Timed out looking for class: %s', classname)
       return None


### PR DESCRIPTION
This reverts commit ceb230ecc3ee7aac44abfbccf997ed06464c72cb.
Issue #72 was fixed by PR #70 "Improved stability of selecting printer job.".
This closes #72.