### PR TITLE
Added interface address command line option for Zeroconf.

### DIFF
--- a/_mdns.py
+++ b/_mdns.py
@@ -63,10 +63,19 @@ class MDnsService(object):
 class MDnsListener(object):
   """A MDNS Listener."""
 
-  def __init__(self, logger):
+  def __init__(self, logger, if_addr=None):
+    """Initialization requires a logger.
+    
+    Args:
+      logger: initialized logger object.
+      if_addr: string, interface address for Zeroconf, None means all interfaces.
+    """
     # self.logger = _log.GetLogger('LogoCert')
     self.logger = logger
-    self.zeroconf = Zeroconf(InterfaceChoice.All)
+    if if_addr:
+      self.zeroconf = Zeroconf([if_addr])
+    else:
+      self.zeroconf = Zeroconf(InterfaceChoice.All)
     self.listener = MDnsService(logger)
 
   def add_listener(self, proto):

--- a/testcert.py
+++ b/testcert.py
@@ -78,6 +78,10 @@ def _ParseArgs():
                     help='Email account to use [default: %default]',
                     default=Constants.USER['EMAIL'],
                     dest='email')
+  parser.add_option('--if-addr',
+                    help='Interface address for Zeroconf',
+                    default=None,
+                    dest='if_addr')
   parser.add_option('--loadtime',
                     help='Seconds for web pages to load [default: %default]',
                     default=10,
@@ -139,7 +143,7 @@ def setUpModule():
   chrome.SignIn(options.email, options.passwd)
   CheckCredentials()
   gcpmgr = _cloudprintmgr.CloudPrintMgr(logger, chromedriver)
-  mdns_browser = _mdns.MDnsListener(logger)
+  mdns_browser = _mdns.MDnsListener(logger, options.if_addr)
   mdns_browser.add_listener('privet')
   # Wait to receive Privet printer advertisements.
   time.sleep(30)


### PR DESCRIPTION
Added interface address command line option for Zeroconf to avoid the following issue.

Zeroconf does not work on most Windows environment, if 'InterfaceChoice.All' is specified on argument.
* "GetAdaptersAddresses()" Windows API returns prefix list contains full interface address on most Windows environment.
 * e.g. 192.168.0.0/24, 192.168.0.10/32, 192.168.0.255/32, 224.0.0.0/4 and 255.255.255.255/32
* 'netifaces' module generates netmask from the longest prefix which matches with the interface address.
 * e.g. 192.168.0.10/32 -> 255.255.255.255
* 'Zeroconf' module uses interfaces which has netmask other than 255.255.255.255.
* Finally, no interface are used by Zeroconf.

This issue does not occur on some Windows environment.
* "GetAdaptersAddresses()" Windows API returns prefix list contains ONLY network address on some Windows environment.
 * e.g. 192.168.0.0/24.
* 'netifaces' module generates netmask from the longest prefix which matches with the interface address.
 * e.g. 192.168.0.0/24 -> 255.255.255.0
* It's OK.

Probably, this issue is bug of 'netifaces' module.