### PR TITLE
Modified JobState to make it more robust.

### DIFF
--- a/_cloudprintmgr.py
+++ b/_cloudprintmgr.py
@@ -711,3 +711,22 @@ class CloudPrintMgr(object):
       if timeout < time.time() - start:
         return job_status
       time.sleep(1)
+
+  def WaitForJobState(self, job_name, state):
+    """Wait until the jobstate is equal to the expected state.
+
+    Args:
+      job_name: string, name (or partial unique name) of print job.
+      state: string, the expected state
+    Returns:
+      string, current status of job.
+
+    """
+    t_end = time.time() + 60 * 10
+
+    while time.time() < t_end:
+      if state == self.GetJobStatus(job_name):
+        return state
+      time.sleep(1)
+
+    return self.GetJobStatus(job_name)

--- a/testcert.py
+++ b/testcert.py
@@ -33,7 +33,7 @@ therefore watch the output of the script while it's running.
 test_id corresponds to an internal database used by Google, so don't change
 those IDs. These IDs are used when submitting test results to our database.
 """
-__version__ = '1.12'
+__version__ = '1.13'
 
 import optparse
 import re
@@ -1789,8 +1789,10 @@ class Registration(LogoCert):
       if chrome.RegisterPrinter(self.printer):
         self.User2RegistrationAttempt(chrome2)
         print 'Now accept the registration request from %s.' % self.username
+        raw_input('Select enter once the registration is accepted.');
+        print 'Waiting 1 minute to complete the registration.'
         #  Allow time for registration to complete.
-        time.sleep(20)
+        time.sleep(60)
         result = chrome.ConfirmPrinterRegistration(self.printer)
         try:
           self.assertTrue(result)
@@ -3356,8 +3358,8 @@ class JobState(LogoCert):
       self.LogTest(test_id, test_name, 'Blocked', notes)
       raise
     else:
-      raw_input('Select enter once 1st page is printed...')
-      job_state = gcpmgr.GetJobStatus('PDF1.7.pdf')
+      print 'When printer starts printing, Job State should transition to in progress.'
+      job_state = gcpmgr.WaitForJobState('PDF1.7.pdf', 'In progress')
       try:
         self.assertEqual(job_state, 'In progress')
       except AssertionError:
@@ -3439,9 +3441,8 @@ class JobState(LogoCert):
           raise
         else:
           print 'Now place paper back in the input tray.'
-          raw_input('Once paper starts printing, select enter...')
-          time.sleep(10)
-          job_state = gcpmgr.GetJobStatus('PDF1.7.pdf')
+          print 'After placing the paper back, Job State should transition to in progress.'
+          job_state = gcpmgr.WaitForJobState('PDF1.7.pdf', 'In progress')
           try:
             self.assertEqual(job_state, 'In progress')
           except AssertionError:
@@ -3452,8 +3453,7 @@ class JobState(LogoCert):
           else:
             print 'Wait for the print job to finish.'
             raw_input('Select enter once the job completes printing...')
-            time.sleep(10)
-            job_state = gcpmgr.GetJobStatus('PDF1.7.pdf')
+            job_state = gcpmgr.WaitForJobState('PDF1.7.pdf', 'Printed')
             try:
               self.assertEqual(job_state, 'Printed')
             except AssertionError:
@@ -3482,7 +3482,7 @@ class JobState(LogoCert):
     if chrome.PrintFile(self.printer, Constants.IMAGES['PDF1.7']):
       # give printer time to update our service.
       time.sleep(10)
-      job_state = gcpmgr.GetJobStatus('PDF1.7.pdf')
+      job_state = gcpmgr.WaitJobStatusNotIn('PDF1.7.pdf', ['Queued', 'In progress'])
       try:
         self.assertEqual(job_state, 'Error')
       except AssertionError:
@@ -3503,9 +3503,8 @@ class JobState(LogoCert):
           raise
         else:
           print 'Now place toner or ink back in printer.'
-          raw_input('Once paper starts printing, select enter...')
-          time.sleep(10)
-          job_state = gcpmgr.GetJobStatus('PDF1.7.pdf')
+          print 'After placing the toner back, Job State should transition to in progress.'
+          job_state = gcpmgr.WaitForJobState('PDF1.7.pdf', 'In progress')
           try:
             self.assertEqual(job_state, 'In progress')
           except AssertionError:
@@ -3516,8 +3515,7 @@ class JobState(LogoCert):
           else:
             print 'Wait for the print job to finish.'
             raw_input('Select enter once the job completes printing...')
-            time.sleep(10)
-            job_state = gcpmgr.GetJobStatus('PDF1.7.pdf')
+            job_state = gcpmgr.WaitForJobState('PDF1.7.pdf', 'Printed')
             try:
               self.assertEqual(job_state, 'Printed')
             except AssertionError:
@@ -3551,9 +3549,8 @@ class JobState(LogoCert):
         raise
       else:
         print 'Re-establish network connection to printer.'
-        raw_input('Select enter once network has been restored....')
-        time.sleep(10)
-        job_state = gcpmgr.GetJobStatus('PDF1.7.pdf')
+        print 'Once network is reconnected, Job state should transition to in progress.'
+        job_state = gcpmgr.WaitForJobState('PDF1.7.pdf', 'In progress')
         try:
           self.assertEqual(job_state, 'In progress')
         except AssertionError:
@@ -3564,8 +3561,7 @@ class JobState(LogoCert):
         else:
           print 'Wait for the print job to finish.'
           raw_input('Select enter once the job completes printing...')
-          time.sleep(10)
-          job_state = gcpmgr.GetJobStatus('PDF1.7.pdf')
+          job_state = gcpmgr.WaitForJobState('PDF1.7.pdf', 'Printed')
           try:
             self.assertEqual(job_state, 'Printed')
           except AssertionError:


### PR DESCRIPTION
The script will now check every second for the job status instead
of checking it after 10 seconds. The script will also check the status
immediately after making the appropriate action (e.g. putting back the paper in tray)
without needing the tester to press enter. This will fix issues/scenarios from the
old implementation like:

1. In the old implementation, after 10 seconds, The script is expecting that
the job status should be 'in progress' after putting back the paper in the tray.
This will work if printing is slow, but there are printers that could print
very fast so there are times that the job status has already transitioned to 'printed'
in less than 10 seconds. So the script will sometimes fail.

2. Tester wasn't able to press the enter button on time after putting back the paper on tray.
During this time, the job status has already been transitioned to
'Printed', so the script will now fail since it's expecting the status
to be 'in-progress' state.

3. If the internet connection is very slow, Job status will only be able
to transition into 'Printed' state after 30 - 60 seconds. So the script will also
fail because it is expecting that the state is already in 'Printed' state in just 10
seconds.

Also modified the Registration suite. Tester now needs to press enter
after registration is accepted. This is to avoid failures when the tester
failed to accept the registration in 20 seconds. Also increased the
timer to 1 minute.