### PR TITLE
Force tester to enter y or n

### DIFF
--- a/testcert.py
+++ b/testcert.py
@@ -350,7 +350,12 @@ class LogoCert(unittest.TestCase):
       Sleep('AUTO_RUN')
       return True
     print 'Did the test produce the expected result?'
-    result = PromptAndWaitForUserAction('Enter "y" or "n"')
+    result = PromptAndWaitForUserAction("Enter 'y' or 'n': ")
+    pattern = re.compile("^[yYnN]")
+    while not pattern.match(result):
+      print ('Invalid input: "' + result + '"')
+      result = PromptAndWaitForUserAction("Enter 'y' or 'n': ")
+    result = result[0].lower()
     try:
       self.assertEqual(result.lower(), 'y')
     except AssertionError:


### PR DESCRIPTION
Test script will fail the testcase if you enter yy or yes etc.
This change requres the tester to enter a string starting with y, Y, n,
or N.