### PR TITLE
Fixed Zeroconf name comparison.

### DIFF
--- a/_zconf.py
+++ b/_zconf.py
@@ -235,7 +235,7 @@ class MDNS_Browser:
     while time.time() < t_end:
       services = self.l.removed_services()
       for service in services:
-        if target_service in service:
+        if target_service.name == service:
           return True
       time.sleep(1)
     return False
@@ -253,7 +253,7 @@ class MDNS_Browser:
     self.logger.info('All listeners have been stopped.')
     return
 
-  def Get_service_ttl(self, name):
+  def Get_service_ttl(self, target_service):
     """Get the printer service's DNS record's TTL
 
     Args:
@@ -262,7 +262,7 @@ class MDNS_Browser:
           integer, TTL if service is found, None otherwise.
     """
     for service in self.l.services():
-      service_name = service.name.lower()
-      if name.lower() in service_name:
+      if target_service.name == service.name:
+        service_name = service.name.lower()
         return self.sb.services[service_name].get_remaining_ttl(time.time()* 1000)
     return None

--- a/testcert.py
+++ b/testcert.py
@@ -2259,7 +2259,7 @@ class LocalDiscovery(LogoCert):
 
     PromptUserAction('Turn off the printer and wait...')
     is_off = mdns_browser.Wait_for_service_remove(120,
-                                                  Constants.PRINTER['NAME'])
+                                                  service)
     try:
       self.assertTrue(is_off)
     except AssertionError:
@@ -2303,11 +2303,11 @@ class LocalDiscovery(LogoCert):
       self.LogTest(test_id, test_name, 'Failed', notes)
       raise
     else:
-      start_ttl = mdns_browser.Get_service_ttl(Constants.PRINTER['NAME'])
+      start_ttl = mdns_browser.Get_service_ttl(service)
       # Monitor the local network for privet broadcasts.
       print 'Listening for network broadcasts for 60 seconds.'
       time.sleep(60)
-      end_ttl = mdns_browser.Get_service_ttl(Constants.PRINTER['NAME'])
+      end_ttl = mdns_browser.Get_service_ttl(service)
       try:
         self.assertTrue(start_ttl > end_ttl)
       except AssertionError:


### PR DESCRIPTION
Changed to compare Zeroconf service name, because the service name does not always contain the device name.