### PR TITLE
Fixed frequently fail after test_04_ConversionPrintingToggle().

### DIFF
--- a/_device.py
+++ b/_device.py
@@ -604,6 +604,33 @@ class Device(object):
 
     return r.json()
 
+  def WaitJobStateIn(self, job_id, job_state, timeout=60):
+    """Wait until the job state becomes the specified state(s)
+
+    Args:
+      job_id: string, id of the print job.
+      job_state: string or list, job state(s) to wait for.
+      timeout: integer, number of seconds to wait.
+    Returns:
+      dict, current job.
+
+    """
+    print ('Waiting up to %s seconds for the job to have one of the following '
+           'job state(s): %s\n' % (timeout, job_state))
+
+    end = time.time() + timeout
+
+    while time.time() < end:
+      job = self.JobState(job_id)
+
+      if job is not None:
+        if job['semantic_state']['state']['type'] in job_state:
+          return job
+
+      Sleep('POLL')
+
+    raise AssertionError
+
 
   def Info(self):
     """Make call to the privet/info API to get the latest printer info

--- a/testcert.py
+++ b/testcert.py
@@ -2631,6 +2631,16 @@ class LocalPrinting(LogoCert):
                 'printing is enabled.')
       self.LogTest(test_id, test_name, 'Failed', notes2)
       raise
+
+    try:
+      _device.WaitJobStateIn(job_id,
+                          GCPConstants.DONE,
+                          timeout=Constants.TIMEOUT['PRINTING'])
+    except AssertionError:
+      notes2 = ('Job state did not transition to Done within %s seconds.'
+               % (Constants.TIMEOUT['PRINTING']))
+      self.LogTest(test_id, test_name, 'Failed', notes2)
+      raise
     else:
       notes2 = ('Able to print an svg file via privet local printing when '
                'conversion printing is re-enabled.')


### PR DESCRIPTION
A test case on 'LocalPrinting' test suite frequently fails because the print job remaining after exiting test_04_ConversionPrintingToggle().

I added wait for finish the print job before exiting test_04_ConversionPrintingToggle() to fix this issue.